### PR TITLE
update the repo name to new name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@music-os/message-schema",
+  "name": "@neume-network/message-schema",
   "version": "0.0.2",
-  "description": "music-os shared message-schema across its components.",
+  "description": "neume-network shared message-schema across its components.",
   "main": "./src/index.mjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/music-os/music-os-message-schema.git"
+    "url": "git+https://github.com/neume-network/message-schema.git"
   },
   "keywords": [
     "message",
     "schema",
-    "music-os"
+    "neume-network"
   ],
   "author": "Tim Daubenschütz <tim@daubenschuetz.de> (https://timdaub.github.io/)",
   "license": "GPL-3.0-only",
   "bugs": {
-    "url": "https://github.com/music-os/music-os-message-schema/issues"
+    "url": "https://github.com/neume-network/message-schema/issues"
   },
-  "homepage": "https://github.com/music-os/music-os-message-schema#readme"
+  "homepage": "https://github.com/neume-network/message-schema#readme"
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# music-os-message-schema
+# message-schema
 
 ## license
 


### PR DESCRIPTION
As the title suggested, the name is changed to `neume-network` and removed `music-os` from package.json and readme.md

for issue #6 